### PR TITLE
rename repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lattice-based-rust
+# ring-LWE, module-LWE
 
 ![example workflow](https://github.com/jacksonwalters/lattice-based-rust/actions/workflows/basic.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
the org. name is currently "lattice-based-cryptography", so the repositories should just reflect the methods being used. in this case, ring-LWE and module-LWE. 